### PR TITLE
Use findAllToEnqueue method on ChannelsResolver to use the same method of connection exporters (#36)

### DIFF
--- a/UPGRADE-0.X.md
+++ b/UPGRADE-0.X.md
@@ -5,9 +5,9 @@
 ### Use findAllToEnqueue method on ChannelsResolver to use the same method of connection exporters (#36)
 
 #### TL;DR
-Replaced the argument type of the ChannelsResolver from the `Sylius\Component\Channel\Repository\ChannelRepositoryInterface` to `Webgriffe\SyliusActiveCampaignPlugin\Repository\ActiveCampaignResourceRepositoryInterface`. This should be the same instance anyway.
+The service `webgriffe.sylius_active_campaign_plugin.resolver.all_enabled_channels` has been replaced with the new service `webgriffe.sylius_active_campaign_plugin.resolver.enqueuable_channels`.
 
 #### BC Breaks
 
 ##### Changed
-- [BC] The parameter $channelRepository of Webgriffe\SyliusActiveCampaignPlugin\Resolver\AllEnabledChannelsResolver#__construct() changed from Sylius\Component\Channel\Repository\ChannelRepositoryInterface to a non-contravariant Webgriffe\SyliusActiveCampaignPlugin\Repository\ActiveCampaignResourceRepositoryInterface
+- [BC] Class Webgriffe\SyliusActiveCampaignPlugin\Resolver\AllEnabledChannelsResolver has been deleted

--- a/UPGRADE-0.X.md
+++ b/UPGRADE-0.X.md
@@ -1,0 +1,13 @@
+# UPGRADE FROM `v0.1.0` TO `v0.2.0`
+
+## Codebase
+
+### Use findAllToEnqueue method on ChannelsResolver to use the same method of connection exporters (#36)
+
+#### TL;DR
+Replaced the argument type of the ChannelsResolver from the `Sylius\Component\Channel\Repository\ChannelRepositoryInterface` to `Webgriffe\SyliusActiveCampaignPlugin\Repository\ActiveCampaignResourceRepositoryInterface`. This should be the same instance anyway.
+
+#### BC Breaks
+
+##### Changed
+- [BC] The parameter $channelRepository of Webgriffe\SyliusActiveCampaignPlugin\Resolver\AllEnabledChannelsResolver#__construct() changed from Sylius\Component\Channel\Repository\ChannelRepositoryInterface to a non-contravariant Webgriffe\SyliusActiveCampaignPlugin\Repository\ActiveCampaignResourceRepositoryInterface

--- a/spec/Resolver/AllEnabledChannelsResolverSpec.php
+++ b/spec/Resolver/AllEnabledChannelsResolverSpec.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace spec\Webgriffe\SyliusActiveCampaignPlugin\Resolver;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
+use Webgriffe\SyliusActiveCampaignPlugin\Repository\ActiveCampaignResourceRepositoryInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Resolver\AllEnabledChannelsResolver;
 use Webgriffe\SyliusActiveCampaignPlugin\Resolver\CustomerChannelsResolverInterface;
 
 final class AllEnabledChannelsResolverSpec extends ObjectBehavior
 {
     public function let(
-        ChannelRepositoryInterface $channelRepository,
+        ActiveCampaignResourceRepositoryInterface $channelRepository,
     ): void {
         $this->beConstructedWith($channelRepository);
     }
@@ -30,12 +30,12 @@ final class AllEnabledChannelsResolverSpec extends ObjectBehavior
     }
 
     public function it_resolves_channels_from_customer(
-        ChannelRepositoryInterface $channelRepository,
+        ActiveCampaignResourceRepositoryInterface $channelRepository,
         CustomerInterface $customer,
         ChannelInterface $channel1,
         ChannelInterface $channel2
     ): void {
-        $channelRepository->findBy(['enabled' => true])->shouldBeCalledOnce()->willReturn([$channel1, $channel2]);
+        $channelRepository->findAllToEnqueue()->shouldBeCalledOnce()->willReturn([$channel1, $channel2]);
 
         $this->resolve($customer)->shouldReturn([$channel1, $channel2]);
     }

--- a/spec/Resolver/EnqueuableChannelsResolverSpec.php
+++ b/spec/Resolver/EnqueuableChannelsResolverSpec.php
@@ -8,10 +8,10 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Repository\ActiveCampaignResourceRepositoryInterface;
-use Webgriffe\SyliusActiveCampaignPlugin\Resolver\AllEnabledChannelsResolver;
+use Webgriffe\SyliusActiveCampaignPlugin\Resolver\EnqueuableChannelsResolver;
 use Webgriffe\SyliusActiveCampaignPlugin\Resolver\CustomerChannelsResolverInterface;
 
-final class AllEnabledChannelsResolverSpec extends ObjectBehavior
+final class EnqueuableChannelsResolverSpec extends ObjectBehavior
 {
     public function let(
         ActiveCampaignResourceRepositoryInterface $channelRepository,
@@ -21,7 +21,7 @@ final class AllEnabledChannelsResolverSpec extends ObjectBehavior
 
     public function it_is_initializable(): void
     {
-        $this->shouldBeAnInstanceOf(AllEnabledChannelsResolver::class);
+        $this->shouldBeAnInstanceOf(EnqueuableChannelsResolver::class);
     }
 
     public function it_implements_customer_channels_resolver_interface(): void
@@ -29,7 +29,7 @@ final class AllEnabledChannelsResolverSpec extends ObjectBehavior
         $this->shouldImplement(CustomerChannelsResolverInterface::class);
     }
 
-    public function it_resolves_channels_from_customer(
+    public function it_resolves_enqueuable_channels(
         ActiveCampaignResourceRepositoryInterface $channelRepository,
         CustomerInterface $customer,
         ChannelInterface $channel1,

--- a/src/Resolver/AllEnabledChannelsResolver.php
+++ b/src/Resolver/AllEnabledChannelsResolver.php
@@ -17,8 +17,6 @@ final class AllEnabledChannelsResolver implements CustomerChannelsResolverInterf
 
     public function resolve(CustomerInterface $customer): array
     {
-        $channels = $this->channelRepository->findAllToEnqueue();
-
-        return $channels;
+        return $this->channelRepository->findAllToEnqueue();
     }
 }

--- a/src/Resolver/AllEnabledChannelsResolver.php
+++ b/src/Resolver/AllEnabledChannelsResolver.php
@@ -4,26 +4,20 @@ declare(strict_types=1);
 
 namespace Webgriffe\SyliusActiveCampaignPlugin\Resolver;
 
-use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
+use Webgriffe\SyliusActiveCampaignPlugin\Repository\ActiveCampaignResourceRepositoryInterface;
 use Webmozart\Assert\Assert;
 
 final class AllEnabledChannelsResolver implements CustomerChannelsResolverInterface
 {
-    private ChannelRepositoryInterface $channelRepository;
-
-    public function __construct(ChannelRepositoryInterface $channelRepository)
+    public function __construct(private ActiveCampaignResourceRepositoryInterface $channelRepository)
     {
-        $this->channelRepository = $channelRepository;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function resolve(CustomerInterface $customer): array
     {
-        $channels = $this->channelRepository->findBy(['enabled' => true]);
+        $channels = $this->channelRepository->findAllToEnqueue();
         Assert::allIsInstanceOf($channels, ChannelInterface::class);
 
         return $channels;

--- a/src/Resolver/AllEnabledChannelsResolver.php
+++ b/src/Resolver/AllEnabledChannelsResolver.php
@@ -7,10 +7,10 @@ namespace Webgriffe\SyliusActiveCampaignPlugin\Resolver;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Repository\ActiveCampaignResourceRepositoryInterface;
-use Webmozart\Assert\Assert;
 
 final class AllEnabledChannelsResolver implements CustomerChannelsResolverInterface
 {
+    /** @param ActiveCampaignResourceRepositoryInterface<ChannelInterface> $channelRepository */
     public function __construct(private ActiveCampaignResourceRepositoryInterface $channelRepository)
     {
     }
@@ -18,7 +18,6 @@ final class AllEnabledChannelsResolver implements CustomerChannelsResolverInterf
     public function resolve(CustomerInterface $customer): array
     {
         $channels = $this->channelRepository->findAllToEnqueue();
-        Assert::allIsInstanceOf($channels, ChannelInterface::class);
 
         return $channels;
     }

--- a/src/Resolver/EnqueuableChannelsResolver.php
+++ b/src/Resolver/EnqueuableChannelsResolver.php
@@ -8,7 +8,7 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Repository\ActiveCampaignResourceRepositoryInterface;
 
-final class AllEnabledChannelsResolver implements CustomerChannelsResolverInterface
+final class EnqueuableChannelsResolver implements CustomerChannelsResolverInterface
 {
     /** @param ActiveCampaignResourceRepositoryInterface<ChannelInterface> $channelRepository */
     public function __construct(private ActiveCampaignResourceRepositoryInterface $channelRepository)

--- a/src/Resources/config/services/command.xml
+++ b/src/Resources/config/services/command.xml
@@ -12,7 +12,7 @@
         <service id="webgriffe.sylius_active_campaign_plugin.command.enqueue_contact_and_ecommerce_customer"
                  class="Webgriffe\SyliusActiveCampaignPlugin\Command\EnqueueContactAndEcommerceCustomerCommand">
             <argument type="service" id="sylius.repository.customer"/>
-            <argument type="service" id="webgriffe.sylius_active_campaign_plugin.resolver.all_enabled_channels"/>
+            <argument type="service" id="webgriffe.sylius_active_campaign_plugin.resolver.enqueuable_channels"/>
             <argument type="service" id="webgriffe.sylius_active_campaign_plugin.enqueuer.contact"/>
             <argument type="service" id="webgriffe.sylius_active_campaign_plugin.enqueuer.ecommerce_customer"/>
             <argument>%webgriffe_sylius_active_campaign.command.enqueue_contact_and_ecommerce_customer.name%</argument>

--- a/src/Resources/config/services/event_subscriber.xml
+++ b/src/Resources/config/services/event_subscriber.xml
@@ -5,7 +5,7 @@
         <service id="webgriffe.sylius_active_campaign_plugin.event_subscriber.customer"
                  class="Webgriffe\SyliusActiveCampaignPlugin\EventSubscriber\CustomerSubscriber">
             <argument type="service" id="messenger.default_bus"/>
-            <argument type="service" id="webgriffe.sylius_active_campaign_plugin.resolver.all_enabled_channels"/>
+            <argument type="service" id="webgriffe.sylius_active_campaign_plugin.resolver.enqueuable_channels"/>
             <argument type="service" id="webgriffe.sylius_active_campaign_plugin.enqueuer.contact"/>
             <argument type="service" id="webgriffe.sylius_active_campaign_plugin.enqueuer.ecommerce_customer"/>
             <argument type="service" id="webgriffe.sylius_active_campaign_plugin.logger"/>

--- a/src/Resources/config/services/resolver.xml
+++ b/src/Resources/config/services/resolver.xml
@@ -2,8 +2,8 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="webgriffe.sylius_active_campaign_plugin.resolver.all_enabled_channels"
-                 class="Webgriffe\SyliusActiveCampaignPlugin\Resolver\AllEnabledChannelsResolver">
+        <service id="webgriffe.sylius_active_campaign_plugin.resolver.enqueuable_channels"
+                 class="Webgriffe\SyliusActiveCampaignPlugin\Resolver\EnqueuableChannelsResolver">
             <argument type="service" id="sylius.repository.channel"/>
         </service>
     </services>


### PR DESCRIPTION
Fixes #36 

Changes proposed in this pull request:
- Use the same method of the ConnectionExporter. This will be more simple for users that choose to export only some channels of the application. It will export only EcommerceCustomer for that Connections.
