### PR TITLE
Export orders and carts only for already exported customers

### DIFF
--- a/src/Doctrine/ORM/ActiveCampaignOrderRepositoryTrait.php
+++ b/src/Doctrine/ORM/ActiveCampaignOrderRepositoryTrait.php
@@ -17,9 +17,11 @@ trait ActiveCampaignOrderRepositoryTrait
         assert($this instanceof EntityRepository);
 
         return $this->createQueryBuilder('o')
+            ->join('o.customer', 'c')
             ->andWhere('o.state = :state')
             ->andWhere('o.customer IS NOT NULL')
             ->andWhere('o.activeCampaignId IS NULL')
+            ->andWhere('c.activeCampaignId IS NOT NULL')
             ->andWhere('o.updatedAt < :terminalDate')
             ->setParameter('state', BaseOrderInterface::STATE_CART)
             ->setParameter('terminalDate', $terminalDate)
@@ -44,7 +46,9 @@ trait ActiveCampaignOrderRepositoryTrait
         assert($this instanceof EntityRepository);
 
         return $this->createQueryBuilder('o')
+            ->join('o.customer', 'c')
             ->where('o.customer IS NOT NULL')
+            ->andWhere('c.activeCampaignId IS NOT NULL')
             ->getQuery()
             ->getResult()
         ;

--- a/tests/DataFixtures/ORM/resources/Command/EnqueueEcommerceAbandonedCartCommandTest/customers.yaml
+++ b/tests/DataFixtures/ORM/resources/Command/EnqueueEcommerceAbandonedCartCommandTest/customers.yaml
@@ -3,11 +3,19 @@ App\Entity\Customer\Customer:
         email: 'jim@email.com'
         first_name: 'James'
         last_name: 'Rodriguez'
+        activeCampaignId: 4
     customer_bob:
         email: 'bob@email.com'
         first_name: 'Bob'
         last_name: 'Marquez'
+        activeCampaignId: 5
     customer_sam:
         email: 'sam@email.com'
         first_name: 'Samuel'
         last_name: 'Storm'
+        activeCampaignId: 6
+    customer_clark:
+        email: 'clark@email.com'
+        first_name: 'Clark'
+        last_name: 'Kent'
+        activeCampaignId: null

--- a/tests/DataFixtures/ORM/resources/Command/EnqueueEcommerceAbandonedCartCommandTest/orders.yaml
+++ b/tests/DataFixtures/ORM/resources/Command/EnqueueEcommerceAbandonedCartCommandTest/orders.yaml
@@ -23,4 +23,12 @@ App\Entity\Order\Order:
         customer: '@customer_sam'
         updatedAt: '<(new DateTime("now"))>'
         activeCampaignId: null
+    cart_new_for_not_exported_customer:
+        channel: '@fashion_shop'
+        state: 'cart'
+        currency_code: 'EUR'
+        locale_code: 'en_US'
+        customer: '@customer_clark'
+        updatedAt: '<(new DateTime("now"))>'
+        activeCampaignId: null
 

--- a/tests/DataFixtures/ORM/resources/Command/EnqueueEcommerceOrderCommandTest/customers.yaml
+++ b/tests/DataFixtures/ORM/resources/Command/EnqueueEcommerceOrderCommandTest/customers.yaml
@@ -3,3 +3,8 @@ App\Entity\Customer\Customer:
         email: 'jim@email.com'
         first_name: 'James'
         last_name: 'Rodriguez'
+        activeCampaignId: 178
+    customer_02:
+        email: 'sam@email.com'
+        first_name: 'Samuel'
+        last_name: 'Pitt'

--- a/tests/DataFixtures/ORM/resources/Command/EnqueueEcommerceOrderCommandTest/orders.yaml
+++ b/tests/DataFixtures/ORM/resources/Command/EnqueueEcommerceOrderCommandTest/orders.yaml
@@ -20,4 +20,9 @@ App\Entity\Order\Order:
         customer: '@customer_01'
         activeCampaignId: 6
         state: 'cancelled'
-
+    order_4:
+        channel: '@fashion_shop'
+        number: '0004'
+        currency_code: 'EUR'
+        locale_code: 'en_US'
+        customer: '@customer_02'


### PR DESCRIPTION
Changes proposed in this pull request:
- Implements the OrderRepository to only exports orders and abandoned carts owned by a customer already exported to ActiveCampaign

@webgriffe/wg-devs what do you think about this PR :shipit:?