### PR TITLE
Remove tags and lists subscription from contact handlers (#53)

### DIFF
--- a/docs/02-Installation.md
+++ b/docs/02-Installation.md
@@ -129,7 +129,7 @@
    }
    ```
    If you have added the ChannelCustomer entity be sure to mark it as a Sylius Resource by adding the following lines in
-   the
+   the `webgriffe_sylius_active_campaign_plugin.yaml` file:
 
     ```yaml
     webgriffe_sylius_active_campaign:

--- a/docs/03_A-First_setup.md
+++ b/docs/03_A-First_setup.md
@@ -4,8 +4,8 @@
 
 Right after installing the plugin, you need to export all the resources to ActiveCampaign if you start from scratch,
 persist the ActiveCampaign resource's id on Sylius resource if you already have ActiveCampaign populated, and/or of
-course, create and associate at the same time if you start from a mixed case. To do this the plugin offers three
-commands to do this.
+course, create and associate at the same time if you start from a mixed case. To do this the plugin offers different
+commands to reach this scope.
 
 ### The Enqueue Connection Command
 
@@ -33,6 +33,20 @@ You can also launch the command without any arguments, it will ask you automatic
 ```shell
 php bin/console webgriffe:active-campaign:enqueue-connection
 ```
+
+### The Enqueue Webhook Command
+
+If you want to maintain updated the list subscriptions status of you customers on Sylius you should enable a webhook for the updates of these subscriptions on ActiveCampaign.
+You could obviously create the webhook manually from the AC's dashboard, but you can also use our command:
+
+```shell
+php bin/console webgriffe:active-campaign:enqueue-webhook --all
+```
+
+This command will create the webhook for all the channels that have an ActiveCampaign list id not nullable. You can also
+launch the previous command with argument the id of the channel for which create a list status update webhook.
+
+> **NOTE!** Be sure to add the `webgriffe_sylius_active_campaign_list_status_webhook` route to your app before launch this command, otherwise the route to call from the webhook could not be resolved.
 
 ### The Enqueue Contact and Ecommerce Customer Command
 
@@ -83,6 +97,42 @@ You can also launch the command without any arguments, it will ask you automatic
 php bin/console webgriffe:active-campaign:enqueue-contact-and-ecommerce-customer
 ```
 
+### The Enqueue Contact Tags Adder Command
+
+If you start from scratch with ActiveCampaign it is probably that you need to add some tags to all of your customers/contacts.
+You can use the Enqueue Contact Tags Adder Command to reach this scope:
+
+```shell
+php bin/console webgriffe:active-campaign:enqueue-contact-tags-adder --all
+```
+
+This command will enqueue to add tags to all the ActiveCampaign's enabled customers of you app. You can also
+launch the previous command with argument the id of the customer for which add the tags.
+
+### The Enqueue Contact Lists Subscription Command
+
+If you start from scratch with ActiveCampaign it is probably that you want to subscribe massively all your customers/contacts to the properly Channel's lists.
+You can use the Enqueue Contact Lists Subscription Command to reach this scope:
+
+```shell
+php bin/console webgriffe:active-campaign:enqueue-contact-lists-subscription --all
+```
+
+This command will enqueue all contact lists subscription for all the customers enabled to export them on ActiveCampaign. You can also
+launch the previous command with argument the id of the customer for which subscribe to lists.
+
+### The Update Contact Lists Subscription Command
+
+Alternatively to the previous command, if you start from an already populated status on ActiveCampaign, it is probably that you want to update massively all your customers/contacts subscription to Channel's lists on you Sylius store.
+This will avoid subscribe to a list when not explicitly requested. You can use the Update Contact Lists Subscription Command to reach this scope:
+
+```shell
+php bin/console webgriffe:active-campaign:update-contact-lists-subscription --all
+```
+
+This command will update all contact lists subscription for all the customers enabled to export them on ActiveCampaign. You can also
+launch the previous command with argument the id of the customer for which update subscription to lists.
+
 ### The Enqueue Ecommerce Order Command
 
 The Enqueue Ecommerce Order Command creates/updates the Sylius Orders/Carts as Ecommerce Order/Abandoned Cart on
@@ -96,22 +146,6 @@ This command allows you to create the history of orders and abandoned carts for 
 creates the orders and carts without the "source" flag enabled. This means that all the automations about carts and
 orders wouldn't start. This is probably what is right for you since it is a historian of orders, but you can customize
 it.
-
-But what if you need to export to ActiveCampaign only some Sylius Orders? Simply, just override the logic inside the
-`findAllToEnqueue` `OrderRepository`'s method. So, you can, for example, exports only orders by some customers.
-
-The EcommerceOrderProductMapper service set the product image url needed to show it in the ActiveCampaign admin
-dashboard but also for the email template. By default, the service will take the first image for the product, but you can
-specify a Sylius image type to use for this purpose (for example you could have a `main` type used to specify the first
-image of the product). Set this parameter in the `webgriffe_sylius_active_campaign_plugin.yaml` file:
-
-```yaml
-webgriffe_sylius_active_campaign:
-    ...
-    mapper:
-        ecommerce_order_product:
-            image_type: 'main'
-```
 
 Also, remember that this command acts like a "create/update ecommerce order on ActiveCampaign" so, if you added an
 order, not from the shop checkout you could launch it without any fear, and it will enqueue the new ecommerce order

--- a/docs/03_B-Events.md
+++ b/docs/03_B-Events.md
@@ -24,8 +24,8 @@ The plugin listen for these customer events:
 - `sylius.customer.post_update`
 - `sylius.customer.post_delete`
 
-The first three will lead to a Contact/Ecommerce Customer Create/Update. The last one will lead to a
-Contact/EcommerceCustomer Remove.
+The first three will lead to a Contact/Ecommerce Customer Create/Update, a ContactTagsAdder and a
+ContactListsSubscriber. The last one will lead to a Contact/EcommerceCustomer Remove.
 
 ### Ecommerce Order events
 

--- a/spec/MessageHandler/Contact/ContactCreateHandlerSpec.php
+++ b/spec/MessageHandler/Contact/ContactCreateHandlerSpec.php
@@ -7,16 +7,11 @@ namespace spec\Webgriffe\SyliusActiveCampaignPlugin\MessageHandler\Contact;
 use App\Entity\Customer\CustomerInterface;
 use InvalidArgumentException;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Sylius\Component\Core\Model\CustomerInterface as SyliusCustomerInterface;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
-use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Client\ActiveCampaignResourceClientInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Mapper\ContactMapperInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactCreate;
-use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactListsSubscriber;
-use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactTagsAdder;
 use Webgriffe\SyliusActiveCampaignPlugin\MessageHandler\Contact\ContactCreateHandler;
 use Webgriffe\SyliusActiveCampaignPlugin\Model\ActiveCampaign\ContactInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Model\ActiveCampaignAwareInterface;
@@ -30,8 +25,7 @@ class ContactCreateHandlerSpec extends ObjectBehavior
         ContactInterface $contact,
         CustomerInterface $customer,
         ActiveCampaignResourceClientInterface $activeCampaignContactClient,
-        CustomerRepositoryInterface $customerRepository,
-        MessageBusInterface $messageBus
+        CustomerRepositoryInterface $customerRepository
     ): void {
         $contactMapper->mapFromCustomer($customer)->willReturn($contact);
 
@@ -39,7 +33,7 @@ class ContactCreateHandlerSpec extends ObjectBehavior
 
         $customerRepository->find(12)->willReturn($customer);
 
-        $this->beConstructedWith($contactMapper, $activeCampaignContactClient, $customerRepository, $messageBus);
+        $this->beConstructedWith($contactMapper, $activeCampaignContactClient, $customerRepository);
     }
 
     public function it_is_initializable(): void
@@ -87,16 +81,13 @@ class ContactCreateHandlerSpec extends ObjectBehavior
         CustomerInterface $customer,
         CustomerRepositoryInterface $customerRepository,
         CreateResourceResponseInterface $createContactResponse,
-        ResourceResponseInterface $contactResponse,
-        MessageBusInterface $messageBus
+        ResourceResponseInterface $contactResponse
     ): void {
         $contactResponse->getId()->willReturn(3423);
         $createContactResponse->getResourceResponse()->willReturn($contactResponse);
         $activeCampaignContactClient->create($contact)->shouldBeCalledOnce()->willReturn($createContactResponse);
         $customer->setActiveCampaignId(3423)->shouldBeCalledOnce();
         $customerRepository->add($customer)->shouldBeCalledOnce();
-        $messageBus->dispatch(Argument::type(ContactTagsAdder::class))->shouldBeCalledOnce()->willReturn(new Envelope(new ContactTagsAdder(12)));
-        $messageBus->dispatch(Argument::type(ContactListsSubscriber::class))->shouldBeCalledOnce()->willReturn(new Envelope(new ContactListsSubscriber(12)));
 
         $this->__invoke(new ContactCreate(12));
     }

--- a/spec/MessageHandler/Contact/ContactUpdateHandlerSpec.php
+++ b/spec/MessageHandler/Contact/ContactUpdateHandlerSpec.php
@@ -7,15 +7,10 @@ namespace spec\Webgriffe\SyliusActiveCampaignPlugin\MessageHandler\Contact;
 use App\Entity\Customer\CustomerInterface;
 use InvalidArgumentException;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Sylius\Component\Core\Model\CustomerInterface as SyliusCustomerInterface;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
-use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Client\ActiveCampaignResourceClientInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Mapper\ContactMapperInterface;
-use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactListsSubscriber;
-use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactTagsAdder;
 use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactUpdate;
 use Webgriffe\SyliusActiveCampaignPlugin\MessageHandler\Contact\ContactUpdateHandler;
 use Webgriffe\SyliusActiveCampaignPlugin\Model\ActiveCampaign\ContactInterface;
@@ -29,8 +24,7 @@ class ContactUpdateHandlerSpec extends ObjectBehavior
         ContactInterface $contact,
         CustomerInterface $customer,
         ActiveCampaignResourceClientInterface $activeCampaignContactClient,
-        CustomerRepositoryInterface $customerRepository,
-        MessageBusInterface $messageBus
+        CustomerRepositoryInterface $customerRepository
     ): void {
         $contactMapper->mapFromCustomer($customer)->willReturn($contact);
 
@@ -38,7 +32,7 @@ class ContactUpdateHandlerSpec extends ObjectBehavior
 
         $customerRepository->find(12)->willReturn($customer);
 
-        $this->beConstructedWith($contactMapper, $activeCampaignContactClient, $customerRepository, $messageBus);
+        $this->beConstructedWith($contactMapper, $activeCampaignContactClient, $customerRepository);
     }
 
     public function it_is_initializable(): void
@@ -94,12 +88,9 @@ class ContactUpdateHandlerSpec extends ObjectBehavior
     public function it_updates_contact_on_active_campaign(
         ContactInterface $contact,
         ActiveCampaignResourceClientInterface $activeCampaignContactClient,
-        UpdateResourceResponseInterface $updateContactResponse,
-        MessageBusInterface $messageBus
+        UpdateResourceResponseInterface $updateContactResponse
     ): void {
         $activeCampaignContactClient->update(1234, $contact)->shouldBeCalledOnce()->willReturn($updateContactResponse);
-        $messageBus->dispatch(Argument::type(ContactTagsAdder::class))->shouldBeCalledOnce()->willReturn(new Envelope(new ContactTagsAdder(12)));
-        $messageBus->dispatch(Argument::type(ContactListsSubscriber::class))->shouldBeCalledOnce()->willReturn(new Envelope(new ContactListsSubscriber(12)));
 
         $this->__invoke(new ContactUpdate(12, 1234));
     }

--- a/src/Command/EnqueueContactListsSubscriptionCommand.php
+++ b/src/Command/EnqueueContactListsSubscriptionCommand.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webgriffe\SyliusActiveCampaignPlugin\Command;
+
+use InvalidArgumentException;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactListsSubscriber;
+use Webgriffe\SyliusActiveCampaignPlugin\Model\CustomerActiveCampaignAwareInterface;
+use Webgriffe\SyliusActiveCampaignPlugin\Repository\ActiveCampaignResourceRepositoryInterface;
+
+final class EnqueueContactListsSubscriptionCommand extends Command
+{
+    use LockableTrait;
+
+    private const CUSTOMER_ID_ARGUMENT_CODE = 'customer-id';
+
+    public const ENQUEUE_CONTACT_LISTS_SUBSCRIPTION_COMMAND_STOPWATCH_NAME = 'enqueue-contact-lists-subscription-command';
+
+    public const ALL_OPTION_CODE = 'all';
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    private SymfonyStyle $io;
+
+    /** @param ActiveCampaignResourceRepositoryInterface<CustomerInterface> $customerRepository */
+    public function __construct(
+        private ActiveCampaignResourceRepositoryInterface $customerRepository,
+        private MessageBusInterface $messageBus,
+        private ?string $name = null
+    ) {
+        parent::__construct($this->name);
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setHelp($this->getCommandHelp())
+            ->addArgument(self::CUSTOMER_ID_ARGUMENT_CODE, InputArgument::OPTIONAL, 'The identifier id of the customer to subscribe to lists.')
+            ->addOption(self::ALL_OPTION_CODE, 'a', InputOption::VALUE_NONE, 'If set, the command will subscribe to lists all customers.')
+        ;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        if ($input->getOption(self::ALL_OPTION_CODE) === true || $input->getArgument(self::CUSTOMER_ID_ARGUMENT_CODE) !== null) {
+            return;
+        }
+
+        $this->io->title('Enqueue Contact Lists Subscription Command Interactive Wizard');
+        $this->io->text([
+            'If you prefer to not use this interactive wizard, provide the',
+            'argument required by this command as follows:',
+            '',
+            ' $ php bin/console ' . (string) $this->name . ' customer-id',
+            '',
+            'Now we\'ll ask you for the value of the customer to subscribe to lists.',
+        ]);
+
+        // Ask for the Customer ID if it's not defined
+        /** @var mixed|null $customerId */
+        $customerId = $input->getArgument(self::CUSTOMER_ID_ARGUMENT_CODE);
+        if (null === $customerId) {
+            /** @var mixed $customerId */
+            $customerId = $this->io->ask('Customer id', null, [$this, 'validateCustomerId']);
+            $input->setArgument(self::CUSTOMER_ID_ARGUMENT_CODE, $customerId);
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->lock()) {
+            $this->io->error('The command is already running in another process.');
+
+            return Command::FAILURE;
+        }
+        $stopwatch = new Stopwatch();
+        $stopwatch->start(self::ENQUEUE_CONTACT_LISTS_SUBSCRIPTION_COMMAND_STOPWATCH_NAME);
+
+        /** @var string|int $customerId */
+        $customerId = $input->getArgument(self::CUSTOMER_ID_ARGUMENT_CODE);
+        $exportAll = (bool) $input->getOption(self::ALL_OPTION_CODE);
+
+        $this->validateInputData($customerId, $exportAll);
+
+        if ($exportAll) {
+            $customersToExport = $this->customerRepository->findAllToEnqueue();
+        } else {
+            $customer = $this->customerRepository->findOneToEnqueue($customerId);
+            if ($customer === null) {
+                throw new InvalidArgumentException(sprintf(
+                    'Unable to find a Customer with id "%s".',
+                    $customerId
+                ));
+            }
+            $customersToExport = [$customer];
+        }
+        if (count($customersToExport) === 0) {
+            $this->io->writeln('No customers founded to subscribe to lists.');
+
+            return Command::SUCCESS;
+        }
+        $progressBar = $this->getProgressBar($output, $customersToExport);
+
+        foreach ($customersToExport as $customer) {
+            if (!$customer instanceof CustomerActiveCampaignAwareInterface) {
+                continue;
+            }
+            /** @var int|string $customerId */
+            $customerId = $customer->getId();
+            $this->messageBus->dispatch(new ContactListsSubscriber($customerId));
+
+            $progressBar->setMessage(sprintf('Customer "%s" enqueued for subscribing to lists!', (string) $customerId), 'status');
+            $progressBar->advance();
+        }
+        $progressBar->setMessage(sprintf('Finished to enqueue the %s customers for subscribing to lists 🎉', count($customersToExport)), 'status');
+        $progressBar->finish();
+
+        $event = $stopwatch->stop(self::ENQUEUE_CONTACT_LISTS_SUBSCRIPTION_COMMAND_STOPWATCH_NAME);
+        $this->io->comment(sprintf('Elapsed time: %.2f ms / Consumed memory: %.2f MB', $event->getDuration(), $event->getMemory() / (1024 ** 2)));
+
+        $this->release();
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param string|int|null $customerId
+     */
+    private function validateInputData(mixed $customerId, bool $all): void
+    {
+        if ($all) {
+            return;
+        }
+        $this->validateCustomerId($customerId);
+    }
+
+    /**
+     * @param string|int|null $customerId
+     *
+     * @return string|int
+     */
+    public function validateCustomerId($customerId)
+    {
+        if ($customerId === null || $customerId === '') {
+            throw new InvalidArgumentException('The Customer id can not be empty.');
+        }
+
+        return $customerId;
+    }
+
+    private function getCommandHelp(): string
+    {
+        return <<<'HELP'
+            The <info>%command.name%</info> command enqueue all Sylius customers to subscribe them to Channel configured lists on ActiveCampaign:
+
+              <info>php %command.full_name%</info> <comment>customer-id</comment>
+
+            By default the command enqueue only one customer. To enqueue all customers,
+            add the <comment>--all</comment> option:
+
+              <info>php %command.full_name%</info> <comment>--all</comment>
+
+            If you omit the argument and the option, the command will ask you to
+            provide the missing customer id:
+
+              # command will ask you for the customer id
+              <info>php %command.full_name%</info>
+            HELP;
+    }
+
+    private function getProgressBar(OutputInterface $output, array $customersToExport): ProgressBar
+    {
+        $progressBar = new ProgressBar($output, count($customersToExport));
+        $progressBar->setFormat(
+            "<fg=white;bg=black> %status:-45s%</>\n%current%/%max% [%bar%] %percent:3s%%\n🏁  %estimated:-21s% %memory:21s%"
+        );
+        $progressBar->setBarCharacter('<fg=red>⚬</>');
+        $progressBar->setEmptyBarCharacter('<fg=blue>⚬</>');
+        $progressBar->setProgressCharacter('🚀');
+        $progressBar->setRedrawFrequency(10);
+        $progressBar->setMessage(sprintf('Starting the enqueue for %s customers...', count($customersToExport)), 'status');
+        $progressBar->start();
+
+        return $progressBar;
+    }
+}

--- a/src/Command/EnqueueContactTagsAdderCommand.php
+++ b/src/Command/EnqueueContactTagsAdderCommand.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webgriffe\SyliusActiveCampaignPlugin\Command;
+
+use InvalidArgumentException;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactTagsAdder;
+use Webgriffe\SyliusActiveCampaignPlugin\Model\CustomerActiveCampaignAwareInterface;
+use Webgriffe\SyliusActiveCampaignPlugin\Repository\ActiveCampaignResourceRepositoryInterface;
+
+final class EnqueueContactTagsAdderCommand extends Command
+{
+    use LockableTrait;
+
+    private const CUSTOMER_ID_ARGUMENT_CODE = 'customer-id';
+
+    public const ENQUEUE_CONTACT_TAGS_ADDER_COMMAND_STOPWATCH_NAME = 'enqueue-contact-tags-adder-command';
+
+    public const ALL_OPTION_CODE = 'all';
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    private SymfonyStyle $io;
+
+    /** @param ActiveCampaignResourceRepositoryInterface<CustomerInterface> $customerRepository */
+    public function __construct(
+        private ActiveCampaignResourceRepositoryInterface $customerRepository,
+        private MessageBusInterface $messageBus,
+        private ?string $name = null
+    ) {
+        parent::__construct($this->name);
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setHelp($this->getCommandHelp())
+            ->addArgument(self::CUSTOMER_ID_ARGUMENT_CODE, InputArgument::OPTIONAL, 'The identifier id of the customer to which add the tags.')
+            ->addOption(self::ALL_OPTION_CODE, 'a', InputOption::VALUE_NONE, 'If set, the command will add tags to all customers.')
+        ;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        if ($input->getOption(self::ALL_OPTION_CODE) === true || $input->getArgument(self::CUSTOMER_ID_ARGUMENT_CODE) !== null) {
+            return;
+        }
+
+        $this->io->title('Enqueue Contact Tags Adder Command Interactive Wizard');
+        $this->io->text([
+            'If you prefer to not use this interactive wizard, provide the',
+            'argument required by this command as follows:',
+            '',
+            ' $ php bin/console ' . (string) $this->name . ' customer-id',
+            '',
+            'Now we\'ll ask you for the value of the customer to which add the tags.',
+        ]);
+
+        // Ask for the Customer ID if it's not defined
+        /** @var mixed|null $customerId */
+        $customerId = $input->getArgument(self::CUSTOMER_ID_ARGUMENT_CODE);
+        if (null === $customerId) {
+            /** @var mixed $customerId */
+            $customerId = $this->io->ask('Customer id', null, [$this, 'validateCustomerId']);
+            $input->setArgument(self::CUSTOMER_ID_ARGUMENT_CODE, $customerId);
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->lock()) {
+            $this->io->error('The command is already running in another process.');
+
+            return Command::FAILURE;
+        }
+        $stopwatch = new Stopwatch();
+        $stopwatch->start(self::ENQUEUE_CONTACT_TAGS_ADDER_COMMAND_STOPWATCH_NAME);
+
+        /** @var string|int $customerId */
+        $customerId = $input->getArgument(self::CUSTOMER_ID_ARGUMENT_CODE);
+        $exportAll = (bool) $input->getOption(self::ALL_OPTION_CODE);
+
+        $this->validateInputData($customerId, $exportAll);
+
+        if ($exportAll) {
+            $customersToWhichAddTags = $this->customerRepository->findAllToEnqueue();
+        } else {
+            $customer = $this->customerRepository->findOneToEnqueue($customerId);
+            if ($customer === null) {
+                throw new InvalidArgumentException(sprintf(
+                    'Unable to find a Customer with id "%s".',
+                    $customerId
+                ));
+            }
+            $customersToWhichAddTags = [$customer];
+        }
+        if (count($customersToWhichAddTags) === 0) {
+            $this->io->writeln('No customers founded to which add tags.');
+
+            return Command::SUCCESS;
+        }
+        $progressBar = $this->getProgressBar($output, $customersToWhichAddTags);
+
+        foreach ($customersToWhichAddTags as $customer) {
+            if (!$customer instanceof CustomerActiveCampaignAwareInterface) {
+                continue;
+            }
+            /** @var int|string $customerId */
+            $customerId = $customer->getId();
+            $this->messageBus->dispatch(new ContactTagsAdder($customerId));
+
+            $progressBar->setMessage(sprintf('Customer "%s" enqueued for adding tags!', (string) $customerId), 'status');
+            $progressBar->advance();
+        }
+        $progressBar->setMessage(sprintf('Finished to enqueue the %s customers for adding tags 🎉', count($customersToWhichAddTags)), 'status');
+        $progressBar->finish();
+
+        $event = $stopwatch->stop(self::ENQUEUE_CONTACT_TAGS_ADDER_COMMAND_STOPWATCH_NAME);
+        $this->io->comment(sprintf('Elapsed time: %.2f ms / Consumed memory: %.2f MB', $event->getDuration(), $event->getMemory() / (1024 ** 2)));
+
+        $this->release();
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param string|int|null $customerId
+     */
+    private function validateInputData(mixed $customerId, bool $all): void
+    {
+        if ($all) {
+            return;
+        }
+        $this->validateCustomerId($customerId);
+    }
+
+    /**
+     * @param string|int|null $customerId
+     *
+     * @return string|int
+     */
+    public function validateCustomerId($customerId)
+    {
+        if ($customerId === null || $customerId === '') {
+            throw new InvalidArgumentException('The Customer id can not be empty.');
+        }
+
+        return $customerId;
+    }
+
+    private function getCommandHelp(): string
+    {
+        return <<<'HELP'
+            The <info>%command.name%</info> command enqueue all Sylius customers to add tags on ActiveCampaign:
+
+              <info>php %command.full_name%</info> <comment>customer-id</comment>
+
+            By default the command enqueue only one customer. To enqueue all customers,
+            add the <comment>--all</comment> option:
+
+              <info>php %command.full_name%</info> <comment>--all</comment>
+
+            If you omit the argument and the option, the command will ask you to
+            provide the missing customer id:
+
+              # command will ask you for the customer id
+              <info>php %command.full_name%</info>
+            HELP;
+    }
+
+    private function getProgressBar(OutputInterface $output, array $customersToExport): ProgressBar
+    {
+        $progressBar = new ProgressBar($output, count($customersToExport));
+        $progressBar->setFormat(
+            "<fg=white;bg=black> %status:-45s%</>\n%current%/%max% [%bar%] %percent:3s%%\n🏁  %estimated:-21s% %memory:21s%"
+        );
+        $progressBar->setBarCharacter('<fg=red>⚬</>');
+        $progressBar->setEmptyBarCharacter('<fg=blue>⚬</>');
+        $progressBar->setProgressCharacter('🚀');
+        $progressBar->setRedrawFrequency(10);
+        $progressBar->setMessage(sprintf('Starting the enqueue for %s customers...', count($customersToExport)), 'status');
+        $progressBar->start();
+
+        return $progressBar;
+    }
+}

--- a/src/Command/UpdateContactListsSubscriptionCommand.php
+++ b/src/Command/UpdateContactListsSubscriptionCommand.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Webgriffe\SyliusActiveCampaignPlugin\Command;
+
+use InvalidArgumentException;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactListsUpdater;
+use Webgriffe\SyliusActiveCampaignPlugin\Model\CustomerActiveCampaignAwareInterface;
+use Webgriffe\SyliusActiveCampaignPlugin\Repository\ActiveCampaignResourceRepositoryInterface;
+
+final class UpdateContactListsSubscriptionCommand extends Command
+{
+    use LockableTrait;
+
+    private const CUSTOMER_ID_ARGUMENT_CODE = 'customer-id';
+
+    public const UPDATE_CONTACT_LISTS_SUBSCRIPTION_COMMAND_STOPWATCH_NAME = 'update-contact-lists-subscription-command';
+
+    public const ALL_OPTION_CODE = 'all';
+
+    /** @psalm-suppress PropertyNotSetInConstructor */
+    private SymfonyStyle $io;
+
+    /** @param ActiveCampaignResourceRepositoryInterface<CustomerInterface> $customerRepository */
+    public function __construct(
+        private ActiveCampaignResourceRepositoryInterface $customerRepository,
+        private MessageBusInterface $messageBus,
+        private ?string $name = null
+    ) {
+        parent::__construct($this->name);
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setHelp($this->getCommandHelp())
+            ->addArgument(self::CUSTOMER_ID_ARGUMENT_CODE, InputArgument::OPTIONAL, 'The identifier id of the customer to which update the subscription to lists status.')
+            ->addOption(self::ALL_OPTION_CODE, 'a', InputOption::VALUE_NONE, 'If set, the command will update the status of list subscriptions for all customers.')
+        ;
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        if ($input->getOption(self::ALL_OPTION_CODE) === true || $input->getArgument(self::CUSTOMER_ID_ARGUMENT_CODE) !== null) {
+            return;
+        }
+
+        $this->io->title('Update Contact Lists Subscription Command Interactive Wizard');
+        $this->io->text([
+            'If you prefer to not use this interactive wizard, provide the',
+            'argument required by this command as follows:',
+            '',
+            ' $ php bin/console ' . (string) $this->name . ' customer-id',
+            '',
+            'Now we\'ll ask you for the value of the customer to which update the list subscriptions status.',
+        ]);
+
+        // Ask for the Customer ID if it's not defined
+        /** @var mixed|null $customerId */
+        $customerId = $input->getArgument(self::CUSTOMER_ID_ARGUMENT_CODE);
+        if (null === $customerId) {
+            /** @var mixed $customerId */
+            $customerId = $this->io->ask('Customer id', null, [$this, 'validateCustomerId']);
+            $input->setArgument(self::CUSTOMER_ID_ARGUMENT_CODE, $customerId);
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->lock()) {
+            $this->io->error('The command is already running in another process.');
+
+            return Command::FAILURE;
+        }
+        $stopwatch = new Stopwatch();
+        $stopwatch->start(self::UPDATE_CONTACT_LISTS_SUBSCRIPTION_COMMAND_STOPWATCH_NAME);
+
+        /** @var string|int $customerId */
+        $customerId = $input->getArgument(self::CUSTOMER_ID_ARGUMENT_CODE);
+        $exportAll = (bool) $input->getOption(self::ALL_OPTION_CODE);
+
+        $this->validateInputData($customerId, $exportAll);
+
+        if ($exportAll) {
+            $customersToUpdate = $this->customerRepository->findAllToEnqueue();
+        } else {
+            $customer = $this->customerRepository->findOneToEnqueue($customerId);
+            if ($customer === null) {
+                throw new InvalidArgumentException(sprintf(
+                    'Unable to find a Customer with id "%s".',
+                    $customerId
+                ));
+            }
+            $customersToUpdate = [$customer];
+        }
+        if (count($customersToUpdate) === 0) {
+            $this->io->writeln('No customers founded to update the list subscriptions.');
+
+            return Command::SUCCESS;
+        }
+        $progressBar = $this->getProgressBar($output, $customersToUpdate);
+
+        foreach ($customersToUpdate as $customer) {
+            if (!$customer instanceof CustomerActiveCampaignAwareInterface) {
+                continue;
+            }
+            /** @var int|string $customerId */
+            $customerId = $customer->getId();
+            $this->messageBus->dispatch(new ContactListsUpdater($customerId));
+
+            $progressBar->setMessage(sprintf('Customer "%s" enqueued for update the list subscriptions status!', (string) $customerId), 'status');
+            $progressBar->advance();
+        }
+        $progressBar->setMessage(sprintf('Finished to enqueue the %s customers for update the list subscriptions status 🎉', count($customersToUpdate)), 'status');
+        $progressBar->finish();
+
+        $event = $stopwatch->stop(self::UPDATE_CONTACT_LISTS_SUBSCRIPTION_COMMAND_STOPWATCH_NAME);
+        $this->io->comment(sprintf('Elapsed time: %.2f ms / Consumed memory: %.2f MB', $event->getDuration(), $event->getMemory() / (1024 ** 2)));
+
+        $this->release();
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param string|int|null $customerId
+     */
+    private function validateInputData(mixed $customerId, bool $all): void
+    {
+        if ($all) {
+            return;
+        }
+        $this->validateCustomerId($customerId);
+    }
+
+    /**
+     * @param string|int|null $customerId
+     *
+     * @return string|int
+     */
+    public function validateCustomerId($customerId)
+    {
+        if ($customerId === null || $customerId === '') {
+            throw new InvalidArgumentException('The Customer id can not be empty.');
+        }
+
+        return $customerId;
+    }
+
+    private function getCommandHelp(): string
+    {
+        return <<<'HELP'
+            The <info>%command.name%</info> command enqueue all Sylius customers to update the list subscriptions status from ActiveCampaign:
+
+              <info>php %command.full_name%</info> <comment>customer-id</comment>
+
+            By default the command enqueue only one customer. To enqueue all customers,
+            add the <comment>--all</comment> option:
+
+              <info>php %command.full_name%</info> <comment>--all</comment>
+
+            If you omit the argument and the option, the command will ask you to
+            provide the missing customer id:
+
+              # command will ask you for the customer id
+              <info>php %command.full_name%</info>
+            HELP;
+    }
+
+    private function getProgressBar(OutputInterface $output, array $customersToExport): ProgressBar
+    {
+        $progressBar = new ProgressBar($output, count($customersToExport));
+        $progressBar->setFormat(
+            "<fg=white;bg=black> %status:-45s%</>\n%current%/%max% [%bar%] %percent:3s%%\n🏁  %estimated:-21s% %memory:21s%"
+        );
+        $progressBar->setBarCharacter('<fg=red>⚬</>');
+        $progressBar->setEmptyBarCharacter('<fg=blue>⚬</>');
+        $progressBar->setProgressCharacter('🚀');
+        $progressBar->setRedrawFrequency(10);
+        $progressBar->setMessage(sprintf('Starting the enqueue for %s customers...', count($customersToExport)), 'status');
+        $progressBar->start();
+
+        return $progressBar;
+    }
+}

--- a/src/MessageHandler/Contact/ContactCreateHandler.php
+++ b/src/MessageHandler/Contact/ContactCreateHandler.php
@@ -7,12 +7,9 @@ namespace Webgriffe\SyliusActiveCampaignPlugin\MessageHandler\Contact;
 use InvalidArgumentException;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Client\ActiveCampaignResourceClientInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Mapper\ContactMapperInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactCreate;
-use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactListsSubscriber;
-use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactTagsAdder;
 use Webgriffe\SyliusActiveCampaignPlugin\Model\ActiveCampaignAwareInterface;
 
 final class ContactCreateHandler
@@ -20,8 +17,7 @@ final class ContactCreateHandler
     public function __construct(
         private ContactMapperInterface $contactMapper,
         private ActiveCampaignResourceClientInterface $activeCampaignContactClient,
-        private CustomerRepositoryInterface $customerRepository,
-        private MessageBusInterface $messageBus
+        private CustomerRepositoryInterface $customerRepository
     ) {
     }
 
@@ -44,8 +40,5 @@ final class ContactCreateHandler
         $createContactResponse = $this->activeCampaignContactClient->create($this->contactMapper->mapFromCustomer($customer));
         $customer->setActiveCampaignId($createContactResponse->getResourceResponse()->getId());
         $this->customerRepository->add($customer);
-
-        $this->messageBus->dispatch(new ContactTagsAdder($customerId));
-        $this->messageBus->dispatch(new ContactListsSubscriber($customerId));
     }
 }

--- a/src/MessageHandler/Contact/ContactUpdateHandler.php
+++ b/src/MessageHandler/Contact/ContactUpdateHandler.php
@@ -7,11 +7,8 @@ namespace Webgriffe\SyliusActiveCampaignPlugin\MessageHandler\Contact;
 use InvalidArgumentException;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Client\ActiveCampaignResourceClientInterface;
 use Webgriffe\SyliusActiveCampaignPlugin\Mapper\ContactMapperInterface;
-use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactListsSubscriber;
-use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactTagsAdder;
 use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactUpdate;
 use Webgriffe\SyliusActiveCampaignPlugin\Model\ActiveCampaignAwareInterface;
 
@@ -20,8 +17,7 @@ final class ContactUpdateHandler
     public function __construct(
         private ContactMapperInterface $contactMapper,
         private ActiveCampaignResourceClientInterface $activeCampaignContactClient,
-        private CustomerRepositoryInterface $customerRepository,
-        private MessageBusInterface $messageBus
+        private CustomerRepositoryInterface $customerRepository
     ) {
     }
 
@@ -42,8 +38,5 @@ final class ContactUpdateHandler
             throw new InvalidArgumentException(sprintf('The Customer with id "%s" has an ActiveCampaign id that does not match. Expected "%s", given "%s".', $customerId, $message->getActiveCampaignId(), (string) $activeCampaignId));
         }
         $this->activeCampaignContactClient->update($message->getActiveCampaignId(), $this->contactMapper->mapFromCustomer($customer));
-
-        $this->messageBus->dispatch(new ContactTagsAdder($customerId));
-        $this->messageBus->dispatch(new ContactListsSubscriber($customerId));
     }
 }

--- a/src/Resources/config/app/config.yaml
+++ b/src/Resources/config/app/config.yaml
@@ -5,6 +5,7 @@ framework:
             'Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactUpdate': main
             'Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactRemove': main
             'Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactTagsAdder': main
+            'Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactListsSubscriber': main
             'Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactListsUpdater': main
 
             'Webgriffe\SyliusActiveCampaignPlugin\Message\Connection\ConnectionCreate': main

--- a/src/Resources/config/services/command.xml
+++ b/src/Resources/config/services/command.xml
@@ -8,6 +8,7 @@
         <parameter key="webgriffe_sylius_active_campaign.command.enqueue_ecommerce_abandoned_cart.name">webgriffe:active-campaign:enqueue-ecommerce-abandoned-cart</parameter>
         <parameter key="webgriffe_sylius_active_campaign.command.enqueue_webhook.name">webgriffe:active-campaign:enqueue-webhook</parameter>
         <parameter key="webgriffe_sylius_active_campaign.command.enqueue_contact_lists_subscription.name">webgriffe:active-campaign:enqueue-contact-lists-subscription</parameter>
+        <parameter key="webgriffe_sylius_active_campaign.command.enqueue_contact_tags_adder.name">webgriffe:active-campaign:enqueue-contact-tags-adder</parameter>
         <parameter key="webgriffe_sylius_active_campaign.cart_becomes_abandoned_period">1 day</parameter>
     </parameters>
     <services>
@@ -59,6 +60,14 @@
             <argument type="service" id="sylius.repository.customer"/>
             <argument type="service" id="messenger.default_bus"/>
             <argument>%webgriffe_sylius_active_campaign.command.enqueue_contact_lists_subscription.name%</argument>
+            <tag name="console.command"/>
+        </service>
+
+        <service id="webgriffe.sylius_active_campaign_plugin.command.enqueue_contact_tags_adder"
+                 class="Webgriffe\SyliusActiveCampaignPlugin\Command\EnqueueContactTagsAdderCommand">
+            <argument type="service" id="sylius.repository.customer"/>
+            <argument type="service" id="messenger.default_bus"/>
+            <argument>%webgriffe_sylius_active_campaign.command.enqueue_contact_tags_adder.name%</argument>
             <tag name="console.command"/>
         </service>
     </services>

--- a/src/Resources/config/services/command.xml
+++ b/src/Resources/config/services/command.xml
@@ -8,6 +8,7 @@
         <parameter key="webgriffe_sylius_active_campaign.command.enqueue_ecommerce_abandoned_cart.name">webgriffe:active-campaign:enqueue-ecommerce-abandoned-cart</parameter>
         <parameter key="webgriffe_sylius_active_campaign.command.enqueue_webhook.name">webgriffe:active-campaign:enqueue-webhook</parameter>
         <parameter key="webgriffe_sylius_active_campaign.command.enqueue_contact_lists_subscription.name">webgriffe:active-campaign:enqueue-contact-lists-subscription</parameter>
+        <parameter key="webgriffe_sylius_active_campaign.command.update_contact_lists_subscription.name">webgriffe:active-campaign:update-contact-lists-subscription</parameter>
         <parameter key="webgriffe_sylius_active_campaign.command.enqueue_contact_tags_adder.name">webgriffe:active-campaign:enqueue-contact-tags-adder</parameter>
         <parameter key="webgriffe_sylius_active_campaign.cart_becomes_abandoned_period">1 day</parameter>
     </parameters>
@@ -60,6 +61,14 @@
             <argument type="service" id="sylius.repository.customer"/>
             <argument type="service" id="messenger.default_bus"/>
             <argument>%webgriffe_sylius_active_campaign.command.enqueue_contact_lists_subscription.name%</argument>
+            <tag name="console.command"/>
+        </service>
+
+        <service id="webgriffe.sylius_active_campaign_plugin.command.update_contact_lists_subscription"
+                 class="Webgriffe\SyliusActiveCampaignPlugin\Command\UpdateContactListsSubscriptionCommand">
+            <argument type="service" id="sylius.repository.customer"/>
+            <argument type="service" id="messenger.default_bus"/>
+            <argument>%webgriffe_sylius_active_campaign.command.update_contact_lists_subscription.name%</argument>
             <tag name="console.command"/>
         </service>
 

--- a/src/Resources/config/services/command.xml
+++ b/src/Resources/config/services/command.xml
@@ -7,6 +7,7 @@
         <parameter key="webgriffe_sylius_active_campaign.command.enqueue_ecommerce_order.name">webgriffe:active-campaign:enqueue-ecommerce-order</parameter>
         <parameter key="webgriffe_sylius_active_campaign.command.enqueue_ecommerce_abandoned_cart.name">webgriffe:active-campaign:enqueue-ecommerce-abandoned-cart</parameter>
         <parameter key="webgriffe_sylius_active_campaign.command.enqueue_webhook.name">webgriffe:active-campaign:enqueue-webhook</parameter>
+        <parameter key="webgriffe_sylius_active_campaign.command.enqueue_contact_lists_subscription.name">webgriffe:active-campaign:enqueue-contact-lists-subscription</parameter>
         <parameter key="webgriffe_sylius_active_campaign.cart_becomes_abandoned_period">1 day</parameter>
     </parameters>
     <services>
@@ -50,6 +51,14 @@
             <argument type="service" id="sylius.repository.channel"/>
             <argument type="service" id="webgriffe.sylius_active_campaign_plugin.enqueuer.webhook"/>
             <argument>%webgriffe_sylius_active_campaign.command.enqueue_webhook.name%</argument>
+            <tag name="console.command"/>
+        </service>
+
+        <service id="webgriffe.sylius_active_campaign_plugin.command.enqueue_contact_lists_subscription"
+                 class="Webgriffe\SyliusActiveCampaignPlugin\Command\EnqueueContactListsSubscriptionCommand">
+            <argument type="service" id="sylius.repository.customer"/>
+            <argument type="service" id="messenger.default_bus"/>
+            <argument>%webgriffe_sylius_active_campaign.command.enqueue_contact_lists_subscription.name%</argument>
             <tag name="console.command"/>
         </service>
     </services>

--- a/src/Resources/config/services/message_handler.xml
+++ b/src/Resources/config/services/message_handler.xml
@@ -7,7 +7,6 @@
             <argument type="service" id="webgriffe.sylius_active_campaign_plugin.mapper.contact"/>
             <argument type="service" id="webgriffe.sylius_active_campaign_plugin.client.active_campaign.contact"/>
             <argument type="service" id="sylius.repository.customer"/>
-            <argument type="service" id="messenger.default_bus"/>
             <tag name="messenger.message_handler"/>
         </service>
 
@@ -16,7 +15,6 @@
             <argument type="service" id="webgriffe.sylius_active_campaign_plugin.mapper.contact"/>
             <argument type="service" id="webgriffe.sylius_active_campaign_plugin.client.active_campaign.contact"/>
             <argument type="service" id="sylius.repository.customer"/>
-            <argument type="service" id="messenger.default_bus"/>
             <tag name="messenger.message_handler"/>
         </service>
 

--- a/tests/DataFixtures/ORM/resources/Command/EnqueueContactListsSubscriptionCommandTest/customers.yaml
+++ b/tests/DataFixtures/ORM/resources/Command/EnqueueContactListsSubscriptionCommandTest/customers.yaml
@@ -1,0 +1,14 @@
+App\Entity\Customer\Customer:
+    customer_jim:
+        email: 'jim@email.com'
+        first_name: 'James'
+        last_name: 'Rodriguez'
+    customer_bob:
+        email: 'bob@email.com'
+        first_name: 'Bob'
+        last_name: 'Rodriguez'
+        activeCampaignId: 32
+    customer_sam:
+        email: 'sam@email.com'
+        first_name: 'Samuel'
+        last_name: 'Freud'

--- a/tests/DataFixtures/ORM/resources/Command/EnqueueContactTagsAdderCommandTest/customers.yaml
+++ b/tests/DataFixtures/ORM/resources/Command/EnqueueContactTagsAdderCommandTest/customers.yaml
@@ -1,0 +1,14 @@
+App\Entity\Customer\Customer:
+    customer_jim:
+        email: 'jim@email.com'
+        first_name: 'James'
+        last_name: 'Rodriguez'
+    customer_bob:
+        email: 'bob@email.com'
+        first_name: 'Bob'
+        last_name: 'Rodriguez'
+        activeCampaignId: 32
+    customer_sam:
+        email: 'sam@email.com'
+        first_name: 'Samuel'
+        last_name: 'Freud'

--- a/tests/DataFixtures/ORM/resources/Command/UpdateContactListsSubscriptionCommandTest/customers.yaml
+++ b/tests/DataFixtures/ORM/resources/Command/UpdateContactListsSubscriptionCommandTest/customers.yaml
@@ -1,0 +1,14 @@
+App\Entity\Customer\Customer:
+    customer_jim:
+        email: 'jim@email.com'
+        first_name: 'James'
+        last_name: 'Rodriguez'
+    customer_bob:
+        email: 'bob@email.com'
+        first_name: 'Bob'
+        last_name: 'Rodriguez'
+        activeCampaignId: 32
+    customer_sam:
+        email: 'sam@email.com'
+        first_name: 'Samuel'
+        last_name: 'Freud'

--- a/tests/Integration/Command/EnqueueContactListsSubscriptionCommandTest.php
+++ b/tests/Integration/Command/EnqueueContactListsSubscriptionCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Webgriffe\SyliusActiveCampaignPlugin\Integration\Command;
+
+use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
+use Symfony\Component\Messenger\Envelope;
+use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactListsSubscriber;
+
+final class EnqueueContactListsSubscriptionCommandTest extends AbstractCommandTest
+{
+    private const FIXTURE_BASE_DIR = __DIR__ . '/../../DataFixtures/ORM/resources/Command/EnqueueContactListsSubscriptionCommandTest';
+
+    private CustomerRepositoryInterface $customerRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->customerRepository = self::getContainer()->get('sylius.repository.customer');
+
+        $fixtureLoader = self::getContainer()->get('fidry_alice_data_fixtures.loader.doctrine');
+        $fixtureLoader->load([
+            self::FIXTURE_BASE_DIR . '/customers.yaml',
+        ], [], [], PurgeMode::createDeleteMode());
+    }
+
+    public function test_that_it_enqueues_contact_lists_subscription(): void
+    {
+        $customer = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
+        self::assertNotNull($customer->getId());
+
+        $commandTester = $this->executeCommand([
+            'customer-id' => $customer->getId(),
+        ], []);
+
+        self::assertEquals(0, $commandTester->getStatusCode());
+
+        $transport = self::getContainer()->get('messenger.transport.main');
+        /** @var Envelope[] $messages */
+        $messages = $transport->get();
+        $this->assertCount(1, $messages);
+        $message = $messages[0];
+        $this->assertInstanceOf(ContactListsSubscriber::class, $message->getMessage());
+        $this->assertEquals($customer->getId(), $message->getMessage()->getCustomerId());
+    }
+
+    public function test_that_it_enqueues_contact_lists_subscription_interactively(): void
+    {
+        $customer = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
+        self::assertNotNull($customer->getId());
+
+        $commandTester = $this->executeCommand([], [
+            $customer->getId(),
+        ]);
+
+        self::assertEquals(0, $commandTester->getStatusCode());
+        $transport = self::getContainer()->get('messenger.transport.main');
+        /** @var Envelope[] $messages */
+        $messages = $transport->get();
+        $this->assertCount(1, $messages);
+        $message = $messages[0];
+        $this->assertInstanceOf(ContactListsSubscriber::class, $message->getMessage());
+        $this->assertEquals($customer->getId(), $message->getMessage()->getCustomerId());
+    }
+
+    public function test_that_it_enqueues_all_contacts_lists_subscription(): void
+    {
+        $commandTester = $this->executeCommand([
+            '--all' => true,
+        ]);
+
+        self::assertEquals(0, $commandTester->getStatusCode());
+
+        $customerJim = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
+        $customerBob = $this->customerRepository->findOneBy(['email' => 'bob@email.com']);
+        $customerSam = $this->customerRepository->findOneBy(['email' => 'sam@email.com']);
+        $transport = self::getContainer()->get('messenger.transport.main');
+        /** @var Envelope[] $messages */
+        $messages = $transport->get();
+        $this->assertCount(3, $messages);
+
+        $message = $messages[0];
+        $this->assertInstanceOf(ContactListsSubscriber::class, $message->getMessage());
+        $this->assertEquals($customerJim->getId(), $message->getMessage()->getCustomerId());
+        $message = $messages[1];
+        $this->assertInstanceOf(ContactListsSubscriber::class, $message->getMessage());
+        $this->assertEquals($customerBob->getId(), $message->getMessage()->getCustomerId());
+        $message = $messages[2];
+        $this->assertInstanceOf(ContactListsSubscriber::class, $message->getMessage());
+        $this->assertEquals($customerSam->getId(), $message->getMessage()->getCustomerId());
+    }
+
+    protected function getCommandDefinition(): string
+    {
+        return 'webgriffe.sylius_active_campaign_plugin.command.enqueue_contact_lists_subscription';
+    }
+}

--- a/tests/Integration/Command/EnqueueContactTagsAdderCommandTest.php
+++ b/tests/Integration/Command/EnqueueContactTagsAdderCommandTest.php
@@ -26,7 +26,7 @@ final class EnqueueContactTagsAdderCommandTest extends AbstractCommandTest
         ], [], [], PurgeMode::createDeleteMode());
     }
 
-    public function test_that_it_enqueues_contact_lists_subscription(): void
+    public function test_that_it_enqueues_contact_tags_adder(): void
     {
         $customer = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
         self::assertNotNull($customer->getId());
@@ -46,7 +46,7 @@ final class EnqueueContactTagsAdderCommandTest extends AbstractCommandTest
         $this->assertEquals($customer->getId(), $message->getMessage()->getCustomerId());
     }
 
-    public function test_that_it_enqueues_contact_lists_subscription_interactively(): void
+    public function test_that_it_enqueues_contact_tags_adder_interactively(): void
     {
         $customer = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
         self::assertNotNull($customer->getId());
@@ -65,7 +65,7 @@ final class EnqueueContactTagsAdderCommandTest extends AbstractCommandTest
         $this->assertEquals($customer->getId(), $message->getMessage()->getCustomerId());
     }
 
-    public function test_that_it_enqueues_all_contacts_lists_subscription(): void
+    public function test_that_it_enqueues_all_contacts_tags_adder(): void
     {
         $commandTester = $this->executeCommand([
             '--all' => true,

--- a/tests/Integration/Command/EnqueueContactTagsAdderCommandTest.php
+++ b/tests/Integration/Command/EnqueueContactTagsAdderCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Webgriffe\SyliusActiveCampaignPlugin\Integration\Command;
+
+use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
+use Symfony\Component\Messenger\Envelope;
+use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactTagsAdder;
+
+final class EnqueueContactTagsAdderCommandTest extends AbstractCommandTest
+{
+    private const FIXTURE_BASE_DIR = __DIR__ . '/../../DataFixtures/ORM/resources/Command/EnqueueContactTagsAdderCommandTest';
+
+    private CustomerRepositoryInterface $customerRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->customerRepository = self::getContainer()->get('sylius.repository.customer');
+
+        $fixtureLoader = self::getContainer()->get('fidry_alice_data_fixtures.loader.doctrine');
+        $fixtureLoader->load([
+            self::FIXTURE_BASE_DIR . '/customers.yaml',
+        ], [], [], PurgeMode::createDeleteMode());
+    }
+
+    public function test_that_it_enqueues_contact_lists_subscription(): void
+    {
+        $customer = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
+        self::assertNotNull($customer->getId());
+
+        $commandTester = $this->executeCommand([
+            'customer-id' => $customer->getId(),
+        ], []);
+
+        self::assertEquals(0, $commandTester->getStatusCode());
+
+        $transport = self::getContainer()->get('messenger.transport.main');
+        /** @var Envelope[] $messages */
+        $messages = $transport->get();
+        $this->assertCount(1, $messages);
+        $message = $messages[0];
+        $this->assertInstanceOf(ContactTagsAdder::class, $message->getMessage());
+        $this->assertEquals($customer->getId(), $message->getMessage()->getCustomerId());
+    }
+
+    public function test_that_it_enqueues_contact_lists_subscription_interactively(): void
+    {
+        $customer = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
+        self::assertNotNull($customer->getId());
+
+        $commandTester = $this->executeCommand([], [
+            $customer->getId(),
+        ]);
+
+        self::assertEquals(0, $commandTester->getStatusCode());
+        $transport = self::getContainer()->get('messenger.transport.main');
+        /** @var Envelope[] $messages */
+        $messages = $transport->get();
+        $this->assertCount(1, $messages);
+        $message = $messages[0];
+        $this->assertInstanceOf(ContactTagsAdder::class, $message->getMessage());
+        $this->assertEquals($customer->getId(), $message->getMessage()->getCustomerId());
+    }
+
+    public function test_that_it_enqueues_all_contacts_lists_subscription(): void
+    {
+        $commandTester = $this->executeCommand([
+            '--all' => true,
+        ]);
+
+        self::assertEquals(0, $commandTester->getStatusCode());
+
+        $customerJim = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
+        $customerBob = $this->customerRepository->findOneBy(['email' => 'bob@email.com']);
+        $customerSam = $this->customerRepository->findOneBy(['email' => 'sam@email.com']);
+        $transport = self::getContainer()->get('messenger.transport.main');
+        /** @var Envelope[] $messages */
+        $messages = $transport->get();
+        $this->assertCount(3, $messages);
+
+        $message = $messages[0];
+        $this->assertInstanceOf(ContactTagsAdder::class, $message->getMessage());
+        $this->assertEquals($customerJim->getId(), $message->getMessage()->getCustomerId());
+        $message = $messages[1];
+        $this->assertInstanceOf(ContactTagsAdder::class, $message->getMessage());
+        $this->assertEquals($customerBob->getId(), $message->getMessage()->getCustomerId());
+        $message = $messages[2];
+        $this->assertInstanceOf(ContactTagsAdder::class, $message->getMessage());
+        $this->assertEquals($customerSam->getId(), $message->getMessage()->getCustomerId());
+    }
+
+    protected function getCommandDefinition(): string
+    {
+        return 'webgriffe.sylius_active_campaign_plugin.command.enqueue_contact_tags_adder';
+    }
+}

--- a/tests/Integration/Command/UpdateContactListsSubscriptionCommandTest.php
+++ b/tests/Integration/Command/UpdateContactListsSubscriptionCommandTest.php
@@ -26,7 +26,7 @@ final class UpdateContactListsSubscriptionCommandTest extends AbstractCommandTes
         ], [], [], PurgeMode::createDeleteMode());
     }
 
-    public function test_that_it_enqueues_contact_lists_subscription(): void
+    public function test_that_it_updates_contact_lists_subscription(): void
     {
         $customer = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
         self::assertNotNull($customer->getId());
@@ -46,7 +46,7 @@ final class UpdateContactListsSubscriptionCommandTest extends AbstractCommandTes
         $this->assertEquals($customer->getId(), $message->getMessage()->getCustomerId());
     }
 
-    public function test_that_it_enqueues_contact_lists_subscription_interactively(): void
+    public function test_that_it_updates_contact_lists_subscription_interactively(): void
     {
         $customer = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
         self::assertNotNull($customer->getId());
@@ -65,7 +65,7 @@ final class UpdateContactListsSubscriptionCommandTest extends AbstractCommandTes
         $this->assertEquals($customer->getId(), $message->getMessage()->getCustomerId());
     }
 
-    public function test_that_it_enqueues_all_contacts_lists_subscription(): void
+    public function test_that_it_updates_all_contacts_lists_subscription(): void
     {
         $commandTester = $this->executeCommand([
             '--all' => true,

--- a/tests/Integration/Command/UpdateContactListsSubscriptionCommandTest.php
+++ b/tests/Integration/Command/UpdateContactListsSubscriptionCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Webgriffe\SyliusActiveCampaignPlugin\Integration\Command;
+
+use Fidry\AliceDataFixtures\Persistence\PurgeMode;
+use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
+use Symfony\Component\Messenger\Envelope;
+use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactListsUpdater;
+
+final class UpdateContactListsSubscriptionCommandTest extends AbstractCommandTest
+{
+    private const FIXTURE_BASE_DIR = __DIR__ . '/../../DataFixtures/ORM/resources/Command/UpdateContactListsSubscriptionCommandTest';
+
+    private CustomerRepositoryInterface $customerRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->customerRepository = self::getContainer()->get('sylius.repository.customer');
+
+        $fixtureLoader = self::getContainer()->get('fidry_alice_data_fixtures.loader.doctrine');
+        $fixtureLoader->load([
+            self::FIXTURE_BASE_DIR . '/customers.yaml',
+        ], [], [], PurgeMode::createDeleteMode());
+    }
+
+    public function test_that_it_enqueues_contact_lists_subscription(): void
+    {
+        $customer = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
+        self::assertNotNull($customer->getId());
+
+        $commandTester = $this->executeCommand([
+            'customer-id' => $customer->getId(),
+        ], []);
+
+        self::assertEquals(0, $commandTester->getStatusCode());
+
+        $transport = self::getContainer()->get('messenger.transport.main');
+        /** @var Envelope[] $messages */
+        $messages = $transport->get();
+        $this->assertCount(1, $messages);
+        $message = $messages[0];
+        $this->assertInstanceOf(ContactListsUpdater::class, $message->getMessage());
+        $this->assertEquals($customer->getId(), $message->getMessage()->getCustomerId());
+    }
+
+    public function test_that_it_enqueues_contact_lists_subscription_interactively(): void
+    {
+        $customer = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
+        self::assertNotNull($customer->getId());
+
+        $commandTester = $this->executeCommand([], [
+            $customer->getId(),
+        ]);
+
+        self::assertEquals(0, $commandTester->getStatusCode());
+        $transport = self::getContainer()->get('messenger.transport.main');
+        /** @var Envelope[] $messages */
+        $messages = $transport->get();
+        $this->assertCount(1, $messages);
+        $message = $messages[0];
+        $this->assertInstanceOf(ContactListsUpdater::class, $message->getMessage());
+        $this->assertEquals($customer->getId(), $message->getMessage()->getCustomerId());
+    }
+
+    public function test_that_it_enqueues_all_contacts_lists_subscription(): void
+    {
+        $commandTester = $this->executeCommand([
+            '--all' => true,
+        ]);
+
+        self::assertEquals(0, $commandTester->getStatusCode());
+
+        $customerJim = $this->customerRepository->findOneBy(['email' => 'jim@email.com']);
+        $customerBob = $this->customerRepository->findOneBy(['email' => 'bob@email.com']);
+        $customerSam = $this->customerRepository->findOneBy(['email' => 'sam@email.com']);
+        $transport = self::getContainer()->get('messenger.transport.main');
+        /** @var Envelope[] $messages */
+        $messages = $transport->get();
+        $this->assertCount(3, $messages);
+
+        $message = $messages[0];
+        $this->assertInstanceOf(ContactListsUpdater::class, $message->getMessage());
+        $this->assertEquals($customerJim->getId(), $message->getMessage()->getCustomerId());
+        $message = $messages[1];
+        $this->assertInstanceOf(ContactListsUpdater::class, $message->getMessage());
+        $this->assertEquals($customerBob->getId(), $message->getMessage()->getCustomerId());
+        $message = $messages[2];
+        $this->assertInstanceOf(ContactListsUpdater::class, $message->getMessage());
+        $this->assertEquals($customerSam->getId(), $message->getMessage()->getCustomerId());
+    }
+
+    protected function getCommandDefinition(): string
+    {
+        return 'webgriffe.sylius_active_campaign_plugin.command.update_contact_lists_subscription';
+    }
+}

--- a/tests/Integration/EventSubscriber/CustomerSubscriberTest.php
+++ b/tests/Integration/EventSubscriber/CustomerSubscriberTest.php
@@ -11,7 +11,9 @@ use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\InMemoryTransport;
 use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactCreate;
+use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactListsSubscriber;
 use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactRemove;
+use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactTagsAdder;
 use Webgriffe\SyliusActiveCampaignPlugin\Message\Contact\ContactUpdate;
 use Webgriffe\SyliusActiveCampaignPlugin\Message\EcommerceCustomer\EcommerceCustomerCreate;
 use Webgriffe\SyliusActiveCampaignPlugin\Message\EcommerceCustomer\EcommerceCustomerRemove;
@@ -49,7 +51,7 @@ final class CustomerSubscriberTest extends AbstractEventDispatcherTest
         $transport = self::getContainer()->get('messenger.transport.main');
         /** @var Envelope[] $messages */
         $messages = $transport->get();
-        $this->assertCount(3, $messages);
+        $this->assertCount(5, $messages);
         $message = $messages[0];
         $this->assertInstanceOf(ContactCreate::class, $message->getMessage());
         $this->assertEquals($customerJim->getId(), $message->getMessage()->getCustomerId());
@@ -61,6 +63,12 @@ final class CustomerSubscriberTest extends AbstractEventDispatcherTest
         $this->assertInstanceOf(EcommerceCustomerCreate::class, $message->getMessage());
         $this->assertEquals($customerJim->getId(), $message->getMessage()->getCustomerId());
         $this->assertEquals($digitalChannel->getId(), $message->getMessage()->getChannelId());
+        $message = $messages[3];
+        $this->assertInstanceOf(ContactTagsAdder::class, $message->getMessage());
+        $this->assertEquals($customerJim->getId(), $message->getMessage()->getCustomerId());
+        $message = $messages[4];
+        $this->assertInstanceOf(ContactListsSubscriber::class, $message->getMessage());
+        $this->assertEquals($customerJim->getId(), $message->getMessage()->getCustomerId());
     }
 
     public function test_that_it_updates_existing_contact_and_existing_ecommerce_customer_on_active_campaign(): void
@@ -74,7 +82,7 @@ final class CustomerSubscriberTest extends AbstractEventDispatcherTest
         $transport = self::getContainer()->get('messenger.transport.main');
         /** @var Envelope[] $messages */
         $messages = $transport->get();
-        $this->assertCount(3, $messages);
+        $this->assertCount(5, $messages);
         $message = $messages[0];
         $this->assertInstanceOf(ContactUpdate::class, $message->getMessage());
         $this->assertEquals($customerBob->getId(), $message->getMessage()->getCustomerId());
@@ -88,6 +96,12 @@ final class CustomerSubscriberTest extends AbstractEventDispatcherTest
         $this->assertInstanceOf(EcommerceCustomerCreate::class, $message->getMessage());
         $this->assertEquals($customerBob->getId(), $message->getMessage()->getCustomerId());
         $this->assertEquals($digitalChannel->getId(), $message->getMessage()->getChannelId());
+        $message = $messages[3];
+        $this->assertInstanceOf(ContactTagsAdder::class, $message->getMessage());
+        $this->assertEquals($customerBob->getId(), $message->getMessage()->getCustomerId());
+        $message = $messages[4];
+        $this->assertInstanceOf(ContactListsSubscriber::class, $message->getMessage());
+        $this->assertEquals($customerBob->getId(), $message->getMessage()->getCustomerId());
     }
 
     public function test_that_it_removes_contact_and_ecommerce_customer_on_active_campaign(): void


### PR DESCRIPTION
Fixes #53

Changes proposed in this pull request:
- Remove tags and lists subscription from contact handlers
- Added command to send to ActiveCampaign all lists subscription
- Added command to send to ActiveCampaign all tags for contact
- Added command to update all list subscriptions status from ActiveCampaign
- [x] Docs these commands