### PR TITLE
Use 0 as default ecommerce order discount amount

### DIFF
--- a/spec/Mapper/EcommerceOrderDiscountMapperSpec.php
+++ b/spec/Mapper/EcommerceOrderDiscountMapperSpec.php
@@ -117,7 +117,7 @@ class EcommerceOrderDiscountMapperSpec extends ObjectBehavior
         $otherPromotion->getCode()->willReturn('OTHER');
         $otherPromotion->getName()->willReturn('Other');
         $ecommerceOrderDiscount->setName('Other')->shouldBeCalledOnce();
-        $ecommerceOrderDiscount->setDiscountAmount(null)->shouldNotBeCalled();
+        $ecommerceOrderDiscount->setDiscountAmount(0)->shouldNotBeCalled();
         $ecommerceOrderDiscount->setType(EcommerceOrderDiscountInterface::ORDER_DISCOUNT_TYPE)->shouldNotBeCalled();
         $ecommerceOrderDiscount->setType(EcommerceOrderDiscountInterface::SHIPPING_DISCOUNT_TYPE)->shouldNotBeCalled();
 

--- a/src/Model/ActiveCampaign/EcommerceOrderDiscount.php
+++ b/src/Model/ActiveCampaign/EcommerceOrderDiscount.php
@@ -9,7 +9,7 @@ final class EcommerceOrderDiscount implements EcommerceOrderDiscountInterface
     public function __construct(
         private ?string $name = null,
         private ?string $type = self::ORDER_DISCOUNT_TYPE,
-        private ?int $discountAmount = null,
+        private int $discountAmount = 0,
     ) {
     }
 
@@ -33,12 +33,12 @@ final class EcommerceOrderDiscount implements EcommerceOrderDiscountInterface
         $this->type = $type;
     }
 
-    public function getDiscountAmount(): ?int
+    public function getDiscountAmount(): int
     {
         return $this->discountAmount;
     }
 
-    public function setDiscountAmount(?int $discountAmount): void
+    public function setDiscountAmount(int $discountAmount): void
     {
         $this->discountAmount = $discountAmount;
     }

--- a/src/Model/ActiveCampaign/EcommerceOrderDiscountInterface.php
+++ b/src/Model/ActiveCampaign/EcommerceOrderDiscountInterface.php
@@ -18,7 +18,7 @@ interface EcommerceOrderDiscountInterface
 
     public function setType(?string $type): void;
 
-    public function getDiscountAmount(): ?int;
+    public function getDiscountAmount(): int;
 
-    public function setDiscountAmount(?int $discountAmount): void;
+    public function setDiscountAmount(int $discountAmount): void;
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Use 0 as default ecommerce order discount amount